### PR TITLE
On update it refreshes the previously selected Farm on the ComboBox.

### DIFF
--- a/src/main/java/moe/maika/fmaptracker/TrackerController.java
+++ b/src/main/java/moe/maika/fmaptracker/TrackerController.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -216,12 +217,31 @@ public class TrackerController {
     }
 
     private void updateFarms(Map<Farm, List<Drop>> farms, List<Farm> sortedFarmList, Map<String, List<Farm>> topFarmsForDuelRank) {
+        // Find ComboBox selected Farm in the updated sortedFarmList (same Duelist and Duel Rank)
+        Farm selectedFarm = getPreviouslySelectedFarm(sortedFarmList);
         saPowFarm.updateTopFarms(topFarmsForDuelRank.getOrDefault("SAPOW", Collections.emptyList()), duelistImages);
         bcdFarm.updateTopFarms(topFarmsForDuelRank.getOrDefault("BCD",  Collections.emptyList()), duelistImages);
         saTecFarm.updateTopFarms(topFarmsForDuelRank.getOrDefault("SATEC",  Collections.emptyList()), duelistImages);
         duelistBox.getItems().setAll(sortedFarmList);
         farmChangeListener.setFarms(farms);
         duelistBox.setDisable(false);
+        if (selectedFarm != null)
+            duelistBox.getSelectionModel().select(selectedFarm);
+    }
+
+    private Farm getPreviouslySelectedFarm(List<Farm> sortedFarmList) {
+        Farm ret = null;
+
+        Farm selectedInput = duelistBox.getValue();
+        if (selectedInput != null) {
+            Optional<Farm> aux = sortedFarmList.stream().filter(
+                    farm -> farm.duelist.equals(selectedInput.duelist) && farm.duelRank.equals(selectedInput.duelRank)
+            ).findFirst();
+            if (aux.isPresent())
+                ret = aux.get();
+        }
+
+        return ret;
     }
 
     public void setSelectedFarm(Farm selected) {

--- a/src/main/java/moe/maika/fmaptracker/TrackerController.java
+++ b/src/main/java/moe/maika/fmaptracker/TrackerController.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -225,23 +224,18 @@ public class TrackerController {
         duelistBox.getItems().setAll(sortedFarmList);
         farmChangeListener.setFarms(farms);
         duelistBox.setDisable(false);
-        if (selectedFarm != null)
+        if(selectedFarm != null)
             duelistBox.getSelectionModel().select(selectedFarm);
     }
 
     private Farm getPreviouslySelectedFarm(List<Farm> sortedFarmList) {
-        Farm ret = null;
-
         Farm selectedInput = duelistBox.getValue();
-        if (selectedInput != null) {
-            Optional<Farm> aux = sortedFarmList.stream().filter(
-                    farm -> farm.duelist.equals(selectedInput.duelist) && farm.duelRank.equals(selectedInput.duelRank)
-            ).findFirst();
-            if (aux.isPresent())
-                ret = aux.get();
+        if(selectedInput != null) {
+            return sortedFarmList.stream().filter(
+                    farm -> farm.duelist().equals(selectedInput.duelist()) && farm.duelRank().equals(selectedInput.duelRank())
+            ).findFirst().orElse(null);
         }
-
-        return ret;
+        return null;
     }
 
     public void setSelectedFarm(Farm selected) {


### PR DESCRIPTION
This will select the previously selected Duelist & Duel Rank when calling the update method is called.
The FarmChangeListener then will update the farms currently shown to the user remove the previous checks/cards obtained.

Has been tested manually while playing and getting checks, and while it should be stable changes no failproof guarantee.