### PR TITLE
Add non-native artifacts that run on JVM

### DIFF
--- a/.github/workflows/build_window.yml
+++ b/.github/workflows/build_window.yml
@@ -1,5 +1,9 @@
 name: Build native
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+
 permissions:
   contents: write
 
@@ -10,16 +14,18 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
 
     continue-on-error: true
 
     steps:
-      # Checkout your code
       - uses: actions/checkout@v4
 
-      # Setup the Windows build environment
-      - name: Add msbuild to PATH
+      # Windows build environment
+      - name: Add MSBuild to PATH
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
 
@@ -31,9 +37,17 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install g++ make zlib1g-dev libgl1-mesa-dev libxtst-dev libharfbuzz-dev libgtk-3-dev libpango1.0-dev libatk1.0-dev
+          sudo apt install -y \
+            g++ \
+            make \
+            zlib1g-dev \
+            libgl1-mesa-dev \
+            libxtst-dev \
+            libharfbuzz-dev \
+            libgtk-3-dev \
+            libpango1.0-dev \
+            libatk1.0-dev
 
-      # Set up GraalVM
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
@@ -42,27 +56,29 @@ jobs:
           java-package: 'jdk+fx'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Make staging directory
-        run: mkdir staging
-
-      - name: Build on Windows
+      - name: Build (Windows)
         if: runner.os == 'Windows'
-        run: .\gradlew.bat nativeCompile
+        run: .\gradlew.bat nativeCompile installDist
 
-      - name: Linux
+      - name: Build (Linux/macOS)
         if: runner.os != 'Windows'
         run: |
           chmod +x gradlew
-          ./gradlew nativeCompile
+          ./gradlew nativeCompile installDist
 
-      # Copy the native binary to the staging directory
-      - name: Copy native image to staging
+      - name: Prepare staging
+        shell: bash
         run: |
-          cp -r build/native/nativeCompile/* staging
-          cp LICENSE.txt staging
+          mkdir -p staging/native
+          mkdir -p staging/jre
 
-      # Upload the staging directory as a build artifact. You will be able to download this after the build finishes.
-      - name: Upload
+          cp -R build/native/nativeCompile/* staging/native/
+          cp LICENSE.txt staging/native/
+
+          cp -R build/install/* staging/jre/
+          cp LICENSE.txt staging/jre/
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
@@ -73,17 +89,38 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
+
     steps:
-      - name: Fetch build artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           path: .
 
-      - name: Zip Windows artifacts
-        run: zip -r FMArchipelagoTracker-windows.zip windows-latest
-  
-      - name: Tar Linux artifacts
-        run: tar -cjf FMArchipelagoTracker-linux.tar.bz2 ubuntu-latest
+      - name: Package Windows native
+        run: |
+          cd windows-latest/native
+          zip -r ../../FMArchipelagoTracker-windows-native.zip .
+
+      - name: Package Windows JRE
+        run: |
+          cd ../jre
+          zip -r ../../FMArchipelagoTracker-windows-jre.zip .
+
+      - name: Package Linux native
+        run: |
+          tar -cjf FMArchipelagoTracker-linux-native.tar.bz2 ubuntu-latest/native
+
+      - name: Package Linux JRE
+        run: |
+          tar -cjf FMArchipelagoTracker-linux-jre.tar.bz2 ubuntu-latest/jre
+
+      - name: Package macOS native
+        run: |
+          tar -cjf FMArchipelagoTracker-macos-native.tar.bz2 macos-latest/native
+
+      - name: Package macOS JRE
+        run: |
+          tar -cjf FMArchipelagoTracker-macos-jre.tar.bz2 macos-latest/jre
 
       - name: Publish release
         uses: softprops/action-gh-release@v1
@@ -91,13 +128,33 @@ jobs:
           fail_on_unmatched_files: true
           prerelease: false
           draft: false
-          files: |
-            FMArchipelagoTracker-windows.zip
-            FMArchipelagoTracker-linux.tar.bz2
           generate_release_notes: true
+
+          files: |
+            FMArchipelagoTracker-windows-native.zip
+            FMArchipelagoTracker-windows-jre.zip
+            FMArchipelagoTracker-linux-native.tar.bz2
+            FMArchipelagoTracker-linux-jre.tar.bz2
+            FMArchipelagoTracker-macos-native.tar.bz2
+            FMArchipelagoTracker-macos-jre.tar.bz2
+
           body: |
-            Windows and Linux builds (x64) of the Yu-Gi-Oh! Forbidden Memories Archipelago Tracker. If you get errors about missing `.dll`s when running on Windows, install the [Microsoft Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe).
+            Windows, macOS, and Linux builds (x64) of the Yu-Gi-Oh! Forbidden Memories Archipelago Tracker.
 
-            The macOS operating system is supported by running from source. Consult the [project's README](https://github.com/sg4e/FMArchipelagoTracker) for directions.
+            ## Native builds
+            Native builds are recommended. These run faster don't require having Java installed.
 
-            The latest `apworld` for Archipelago is available at [https://github.com/sg4e/Archipelago/releases](https://github.com/sg4e/Archipelago/releases).
+            **Windows users:** If you receive errors about missing `.dll` files, install the Microsoft Visual C++ Redistributable:
+            https://aka.ms/vs/17/release/vc_redist.x64.exe
+
+            ## JRE builds
+            These builds require installing Java (JRE or JDK) version 25 or later. They are slower than native builds but tend to have better compatibility
+            over a wide range of PCs. Choose a JRE build if the native build isn't working properly for you.
+
+            Launch using:
+
+            - Windows: `bin/FMArchipelagoTracker.bat`
+            - Linux/macOS: `bin/FMArchipelagoTracker`
+
+            The latest Archipelago `.apworld` is available at:
+            https://github.com/sg4e/Archipelago/releases

--- a/.github/workflows/build_window.yml
+++ b/.github/workflows/build_window.yml
@@ -17,7 +17,6 @@ jobs:
         os:
           - windows-latest
           - ubuntu-latest
-          - macos-latest
 
     continue-on-error: true
 
@@ -114,14 +113,6 @@ jobs:
         run: |
           tar -cjf FMArchipelagoTracker-linux-jre.tar.bz2 ubuntu-latest/jre
 
-      - name: Package macOS native
-        run: |
-          tar -cjf FMArchipelagoTracker-macos-native.tar.bz2 macos-latest/native
-
-      - name: Package macOS JRE
-        run: |
-          tar -cjf FMArchipelagoTracker-macos-jre.tar.bz2 macos-latest/jre
-
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
@@ -135,11 +126,9 @@ jobs:
             FMArchipelagoTracker-windows-jre.zip
             FMArchipelagoTracker-linux-native.tar.bz2
             FMArchipelagoTracker-linux-jre.tar.bz2
-            FMArchipelagoTracker-macos-native.tar.bz2
-            FMArchipelagoTracker-macos-jre.tar.bz2
 
           body: |
-            Windows, macOS, and Linux builds (x64) of the Yu-Gi-Oh! Forbidden Memories Archipelago Tracker.
+            Windows and Linux builds (x64) of the Yu-Gi-Oh! Forbidden Memories Archipelago Tracker.
 
             ## Native builds
             Native builds are recommended. These run faster don't require having Java installed.
@@ -154,7 +143,7 @@ jobs:
             Launch using:
 
             - Windows: `bin/FMArchipelagoTracker.bat`
-            - Linux/macOS: `bin/FMArchipelagoTracker`
+            - Linux: `bin/FMArchipelagoTracker`
 
             The latest Archipelago `.apworld` is available at:
             https://github.com/sg4e/Archipelago/releases


### PR DESCRIPTION
Compiling for native with GraalVM has gotten better since this project's first release, but I think having a JVM option is still useful for edge cases and is more future-proof than relying solely on GraalVM. I've discovered that GraalVM supports deploying for native and JVM with the `installDist` instruction, so adding JVM releases is simple. The Polyglot project has fully detached itself from GraalVM reliance, which helps make JVM releases now possible. Running on JVM is slower than native but not restrictively so.